### PR TITLE
refactor: reimplment Revoker

### DIFF
--- a/botoy/_internal/contrib.py
+++ b/botoy/_internal/contrib.py
@@ -299,10 +299,6 @@ zeroWidthChars = {
     8: "\u2060",  # U+2060 Word Joiner
     9: "\u202A",  # U+202A Left-To-Right Embedding
     10: "\u202B",  # U+202B Right-To-Left Embedding
-    11: "\u202C",  # U+202C Pop Directional Formatting
-    12: "\u202D",  # U+202D Left-To-Right Override
-    13: "\u202E",  # U+202E Right-To-Left Override
-    14: "\u202F",  # U+202F Narrow No-Break Space
 }
 
 

--- a/botoy/_internal/contrib.py
+++ b/botoy/_internal/contrib.py
@@ -307,6 +307,7 @@ class Revoker:
 
     @staticmethod
     def _encode_timeout(timeout):
+        """将超时时间编码为零宽字符序列"""
         timeout_chars = []
         if timeout == 0:
             timeout_chars.append(zeroWidthChars[1])
@@ -320,6 +321,7 @@ class Revoker:
 
     @staticmethod
     def _decode_timeout(timeout_chars):
+        """将零宽字符序列解码为超时时间"""
         timeout = 0
         zeroWidthCharsReverse = {v: k for k, v in zeroWidthChars.items()}
         i = 0

--- a/botoy/_internal/contrib.py
+++ b/botoy/_internal/contrib.py
@@ -301,6 +301,7 @@ zeroWidthChars = {
     10: "\u202B",  # U+202B Right-To-Left Embedding
 }
 
+
 class Revoker:
     __slots__ = ()
 

--- a/botoy/_internal/contrib.py
+++ b/botoy/_internal/contrib.py
@@ -301,7 +301,6 @@ zeroWidthChars = {
     10: "\u202B",  # U+202B Right-To-Left Embedding
 }
 
-
 class Revoker:
     __slots__ = ()
 
@@ -310,28 +309,32 @@ class Revoker:
         """将超时时间编码为零宽字符序列"""
         timeout_chars = []
         if timeout == 0:
+            # 特殊情况处理：超时为0时，使用第一个零宽字符
             timeout_chars.append(zeroWidthChars[1])
         else:
+            # 将每一位数字转换为对应的零宽字符
             while timeout > 0:
-                digit = (timeout % 10) + 1
-                char = zeroWidthChars[digit]
-                timeout_chars.insert(0, char)
-                timeout = timeout // 10
-        return "".join(timeout_chars)
+                digit = (timeout % 10) + 1  # 转换数字到1-10范围
+                char = zeroWidthChars[digit]  # 获取对应的零宽字符
+                timeout_chars.insert(0, char)  # 插入字符到前面
+                timeout = timeout // 10  # 继续处理下一个数字
+        return "".join(timeout_chars)  # 将字符列表组合成字符串
 
     @staticmethod
     def _decode_timeout(timeout_chars):
         """将零宽字符序列解码为超时时间"""
         timeout = 0
+        # 创建反向映射，从零宽字符到数字
         zeroWidthCharsReverse = {v: k for k, v in zeroWidthChars.items()}
         i = 0
         while i < len(timeout_chars):
             char = timeout_chars[i : i + 1]
             if char in zeroWidthCharsReverse:
+                # 将零宽字符转换回数字并构建超时时间
                 timeout = timeout * 10 + (zeroWidthCharsReverse[char] - 1)
-                i += 1
+                i += 1  # 继续处理下一个字符
             else:
-                i += 1
+                i += 1  # 跳过不匹配的字符
         return timeout
 
     @staticmethod
@@ -341,10 +344,10 @@ class Revoker:
         :param timeout: 等待延时，5 <= timeout <= 90。默认30
         :return: 新文本
         """
-        timeout = min(max(timeout, 5), 90)
-        delay_marker = zeroWidthChars[1]
-        timeout_marker = Revoker._encode_timeout(timeout)
-        return text + delay_marker + timeout_marker
+        timeout = min(max(timeout, 5), 90)  # 确保超时在合法范围内
+        delay_marker = zeroWidthChars[1]  # 使用第一个零宽字符作为标记
+        timeout_marker = Revoker._encode_timeout(timeout)  # 编码超时编码为零宽字符序列
+        return text + delay_marker + timeout_marker  # 将标记和编码后的超时附加到文本后
 
     @staticmethod
     def check(text: str) -> int:
@@ -353,12 +356,13 @@ class Revoker:
         :param text: 文本内容
         :return: 等待延时
         """
-        delay_marker = zeroWidthChars[1]
-        marker_pos = text.find(delay_marker)
+        delay_marker = zeroWidthChars[1]  # 标记零宽字符
+        marker_pos = text.find(delay_marker)  # 查找标记字符的位置
 
         if marker_pos != -1:
+            # 找到标记，解码超时时间
             timeout_chars = text[marker_pos + len(delay_marker) :]
             timeout = Revoker._decode_timeout(timeout_chars)
-            return timeout
+            return timeout  # 返回解码后的超时时间
 
-        return 0
+        return 0  # 未找到标记，返回0表示无需撤回

--- a/botoy/_internal/contrib.py
+++ b/botoy/_internal/contrib.py
@@ -289,25 +289,26 @@ def sync_run(func):
 
 # Zero-width character mapping
 zeroWidthChars = {
-    1: '\u200B',  # U+200B Zero Width Space
-    2: '\u200C',  # U+200C Zero Width Non-Joiner
-    3: '\u200D',  # U+200D Zero Width Joiner
-    4: '\u200E',  # U+200E Left-To-Right Mark
-    5: '\u200F',  # U+200F Right-To-Left Mark
-    6: '\uFEFF',  # U+FEFF Zero Width No-Break Space
-    7: '\u205F',  # U+205F Medium Mathematical Space
-    8: '\u2060',  # U+2060 Word Joiner
-    9: '\u202A',  # U+202A Left-To-Right Embedding
-    10: '\u202B', # U+202B Right-To-Left Embedding
-    11: '\u202C', # U+202C Pop Directional Formatting
-    12: '\u202D', # U+202D Left-To-Right Override
-    13: '\u202E', # U+202E Right-To-Left Override
-    14: '\u202F'  # U+202F Narrow No-Break Space
+    1: "\u200B",  # U+200B Zero Width Space
+    2: "\u200C",  # U+200C Zero Width Non-Joiner
+    3: "\u200D",  # U+200D Zero Width Joiner
+    4: "\u200E",  # U+200E Left-To-Right Mark
+    5: "\u200F",  # U+200F Right-To-Left Mark
+    6: "\uFEFF",  # U+FEFF Zero Width No-Break Space
+    7: "\u205F",  # U+205F Medium Mathematical Space
+    8: "\u2060",  # U+2060 Word Joiner
+    9: "\u202A",  # U+202A Left-To-Right Embedding
+    10: "\u202B",  # U+202B Right-To-Left Embedding
+    11: "\u202C",  # U+202C Pop Directional Formatting
+    12: "\u202D",  # U+202D Left-To-Right Override
+    13: "\u202E",  # U+202E Right-To-Left Override
+    14: "\u202F",  # U+202F Narrow No-Break Space
 }
+
 
 class Revoker:
     __slots__ = ()
-    
+
     @staticmethod
     def _encode_timeout(timeout):
         timeout_chars = []
@@ -319,15 +320,15 @@ class Revoker:
                 char = zeroWidthChars[digit]
                 timeout_chars.insert(0, char)
                 timeout = timeout // 10
-        return ''.join(timeout_chars)
-    
+        return "".join(timeout_chars)
+
     @staticmethod
     def _decode_timeout(timeout_chars):
         timeout = 0
         zeroWidthCharsReverse = {v: k for k, v in zeroWidthChars.items()}
         i = 0
         while i < len(timeout_chars):
-            char = timeout_chars[i:i + 1]
+            char = timeout_chars[i : i + 1]
             if char in zeroWidthCharsReverse:
                 timeout = timeout * 10 + (zeroWidthCharsReverse[char] - 1)
                 i += 1
@@ -356,10 +357,10 @@ class Revoker:
         """
         delay_marker = zeroWidthChars[1]
         marker_pos = text.find(delay_marker)
-        
+
         if marker_pos != -1:
-            timeout_chars = text[marker_pos + len(delay_marker):]
+            timeout_chars = text[marker_pos + len(delay_marker) :]
             timeout = Revoker._decode_timeout(timeout_chars)
             return timeout
-        
+
         return 0


### PR DESCRIPTION
use zero-width character mapping for encoding/decoding timeout values. Optimize methods for marking and checking text.